### PR TITLE
Minor patch to fix the target functionality after ebird redesign

### DIFF
--- a/js/eBird-target.js
+++ b/js/eBird-target.js
@@ -20,7 +20,7 @@ document.addEventListener("click", function (e) {
           speciesCode: res.querySelector('.ResultsStats-action a').href.split("/map/")[1].split("?")[0],
           commonName: res.querySelector(".SpecimenHeader-joined" + (cat == "hybrids" ? "" : " a")).innerHTML.replace(/\r?\n|\r/g, '').replace(/\t/g, '').split(' <em')[0],
           sciName: res.querySelector(".SpecimenHeader-joined" + (cat == "hybrids" ? "" : " a") + " em") ? res.querySelector(".SpecimenHeader-joined" + (cat == "hybrids" ? "" : " a") + " em").innerText : "",
-          frequency: res.querySelector('.StatsIcon-stat-count').innerText,
+          frequency: res.querySelector('.ResultsStats-stats .Heading').innerText,
           exoticCategory: res.querySelector(".ResultsStats-title button") ? res.querySelector(".ResultsStats-title button").title.split("Exotic: ")[1] : "Native"
         }
       })


### PR DESCRIPTION
Per this facebook post: https://www.facebook.com/groups/288737854555183/permalink/7257888854306680/

The target species functionality seems to be broken due to the ebird site redesign due to element changes in the percentages. I've updated the query selector to fix this.